### PR TITLE
Do not change evens property of parent views

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "gulp-sourcemaps": "^1.3.0",
     "gulp-uglify": "^1.2.0",
     "isparta": "^3.0.3",
+    "jquery": "^2.1.4",
+    "jsdom": "^3.1.2",
     "mocha": "^2.1.0",
     "run-sequence": "^1.0.2",
     "sinon": "^1.12.2",

--- a/src/backbone-decorators.js
+++ b/src/backbone-decorators.js
@@ -12,6 +12,9 @@ import Backbone from 'backbone';
 
 export function on(eventName) {
     return function(target, name, descriptor) {
+        if (target.events && !_.has(target, 'events')) {
+            target.events = _.clone(target.events)
+        }
         if (!target.events) {
             target.events = {};
         }

--- a/test/setup/node.js
+++ b/test/setup/node.js
@@ -2,5 +2,9 @@ global.chai = require('chai');
 global.sinon = require('sinon');
 global.chai.use(require('sinon-chai'));
 
-require('babel-core/register');
+var jsdom = require('jsdom').jsdom;
+global.document = jsdom('<html><head></head><body></body></html>', {});
+global.window = document.parentWindow;
+
+require('babel-core/register')({optional: ['es7.decorators']});
 require('./setup')();

--- a/test/unit/on.spec.js
+++ b/test/unit/on.spec.js
@@ -1,0 +1,30 @@
+import {View} from 'backbone';
+import $ from 'jquery';
+import {on} from '../../src/backbone-decorators';
+import {expect} from 'chai';
+
+describe('@on decorator', () => {
+    it('should gather events configuration from decorated functions', () => {
+        class MyView extends View {
+            @on('click')
+            handleViewClick() {
+                this.viewClicked = true;
+            }
+
+            @on('click .item')
+            handleItemClick() {
+                this.itemClicked = true;
+            }
+        }
+
+        var element = $('<div><span class="item"></span></div>')
+        var view = new MyView({el: element});
+        sinon.spy(view, "handleViewClick");
+
+        element.trigger('click');
+        expect(view.viewClicked).to.be.ok;
+
+        element.find('.item').trigger('click');
+        expect(view.itemClicked).to.be.ok;
+    });
+});

--- a/test/unit/on.spec.js
+++ b/test/unit/on.spec.js
@@ -27,4 +27,28 @@ describe('@on decorator', () => {
         element.find('.item').trigger('click');
         expect(view.itemClicked).to.be.ok;
     });
+
+    it('should not affect parent views', () => {
+        class ParentView extends View {
+            @on('click .item')
+            handleItemClick() {
+                this.itemClicked = true;
+            }
+
+            handleViewClick() {
+                this.viewClicked = true;
+            }
+        }
+
+        class DerivedView extends ParentView {
+            @on('click')
+            handleViewClick() {
+                super.handleViewClick();
+            }
+        }
+
+        var parent = new ParentView();
+        parent.$el.trigger('click');
+        expect(parent.viewClicked).not.to.be.true;
+    });
 });


### PR DESCRIPTION
If you use decorator in a derived view, configuration will be added into parent `events` property. It can cause side-effects as described in the test.

But anyway, thanks for nice library! I started to use it in my project on it is going well.
