### PR TITLE
Relax backbone dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/benmccormick/backbone-decorators",
   "dependencies": {
-    "backbone": "1.0.0 - 1.2.3",
+    "backbone": "^1.0.0",
     "underscore": "1.4.4 - 1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
When Backbone 1.3 was out, it was a real pain to went through all satellite projects like Marionette and ask them to bump Backbone dependency. Now in my projects only this package left.

According to the source code, you are relying on Backbone only in [one place](https://github.com/benmccormick/backbone-decorators/blob/master/src/backbone-decorators.js#L47). That means we can use any Backbone version that has `Model` class, so any `1.x` version will be ok there.
